### PR TITLE
Security fix for avoiding XSS

### DIFF
--- a/lib/strip_html.js
+++ b/lib/strip_html.js
@@ -10,6 +10,9 @@ function striptags(html = '') {
   let depth = 0;
   let in_quote_char = '';
   let output = '';
+  if (typeof html != "string") {
+    throw new TypeError("'html' parameter must be a string");
+  }
 
   const { length } = html;
 


### PR DESCRIPTION
fix: throw TypeError if 'html' is non-string argument